### PR TITLE
:arrow_up: Dependabot rocks - bump backend dependencies

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -70,7 +70,7 @@ django-taggit==1.3.0
     # via -r requirements/base.in
 django-treebeard==4.3.1
     # via -r requirements/base.in
-django==2.2.24
+django==2.2.27
     # via
     #   -r requirements/base.in
     #   django-appconf
@@ -103,7 +103,7 @@ idna==2.10
     # via requests
 jdcal==1.4.1
     # via openpyxl
-lxml==4.6.3
+lxml==4.7.1
     # via -r requirements/base.in
 markuppy==1.14
     # via tablib
@@ -117,7 +117,7 @@ openpyxl==3.0.5
     #   tablib
 packaging==20.8
     # via bleach
-pillow==8.2.0
+pillow==8.4.0
     # via
     #   -r requirements/base.in
     #   cairosvg
@@ -141,7 +141,7 @@ python-dotenv==0.15.0
     # via -r requirements/base.in
 python-memcached==1.59
     # via -r requirements/base.in
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/base.in
     #   django
@@ -167,7 +167,7 @@ six==1.15.0
     #   python-memcached
 sorl-thumbnail==12.7.0
     # via -r requirements/base.in
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via django
 tablib[html,ods,xls,xlsx,yaml]==1.1.0
     # via django-import-export

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -96,7 +96,7 @@ django-treebeard==4.3.1
     # via -r requirements/base.txt
 django-webtest==1.9.7
     # via -r requirements/test-tools.in
-django==2.2.24
+django==2.2.27
     # via
     #   -r requirements/base.txt
     #   django-appconf
@@ -143,7 +143,7 @@ jdcal==1.4.1
     # via
     #   -r requirements/base.txt
     #   openpyxl
-lxml==4.6.3
+lxml==4.7.1
     # via -r requirements/base.txt
 markuppy==1.14
     # via
@@ -163,7 +163,7 @@ packaging==20.8
     # via
     #   -r requirements/base.txt
     #   bleach
-pillow==8.2.0
+pillow==8.4.0
     # via
     #   -r requirements/base.txt
     #   cairosvg
@@ -198,7 +198,7 @@ python-dotenv==0.15.0
     # via -r requirements/base.txt
 python-memcached==1.59
     # via -r requirements/base.txt
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/base.txt
     #   django
@@ -241,7 +241,7 @@ sorl-thumbnail==12.7.0
     # via -r requirements/base.txt
 soupsieve==2.0
     # via beautifulsoup4
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
     #   django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -122,7 +122,7 @@ django-treebeard==4.3.1
     # via -r requirements/ci.txt
 django-webtest==1.9.7
     # via -r requirements/ci.txt
-django==2.2.24
+django==2.2.27
     # via
     #   -r requirements/ci.txt
     #   django-appconf
@@ -188,7 +188,7 @@ jdcal==1.4.1
     #   openpyxl
 jinja2==2.11.3
     # via sphinx
-lxml==4.6.3
+lxml==4.7.1
     # via -r requirements/ci.txt
 markuppy==1.14
     # via
@@ -217,7 +217,7 @@ pathspec==0.8.0
     # via black
 pep517==0.10.0
     # via pip-tools
-pillow==8.2.0
+pillow==8.4.0
     # via
     #   -r requirements/ci.txt
     #   cairosvg
@@ -262,7 +262,7 @@ python-dotenv==0.15.0
     # via -r requirements/ci.txt
 python-memcached==1.59
     # via -r requirements/ci.txt
-pytz==2021.1
+pytz==2021.3
     # via
     #   -r requirements/ci.txt
     #   babel
@@ -335,7 +335,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlparse==0.4.1
+sqlparse==0.4.2
     # via
     #   -r requirements/ci.txt
     #   django


### PR DESCRIPTION
Bumped:

* Django
* LXML
* Pillow
* SQLParse
* pytz (just because we can)
