### PR TITLE
:lock: Set minimum required recaptcha score

### DIFF
--- a/src/brouwers/users/forms/auth.py
+++ b/src/brouwers/users/forms/auth.py
@@ -80,7 +80,9 @@ class AdminUserCreationForm(forms.ModelForm):
 
 
 class UserCreationForm(AdminUserCreationForm):
-    captcha = ReCaptchaField(widget=ReCaptchaV3(action="signup"))
+    captcha = ReCaptchaField(
+        widget=ReCaptchaV3(action="signup", attrs={"required_score": 0.5})
+    )
     accept_terms = forms.BooleanField(
         label=_("I have read and accepted the registration terms"), required=True
     )

--- a/src/brouwers/users/models.py
+++ b/src/brouwers/users/models.py
@@ -29,7 +29,7 @@ class UserManager(BaseUserManager):
             is_superuser=False,
             last_login=now,
             date_joined=now,
-            **extra_fields
+            **extra_fields,
         )
 
         user.set_password(password)

--- a/src/brouwers/utils/tests/recaptcha.py
+++ b/src/brouwers/utils/tests/recaptcha.py
@@ -6,6 +6,10 @@ from django_recaptcha.client import RecaptchaResponse
 def mock_recaptcha(is_valid: bool = True, action=None):
     patcher = patch(
         "django_recaptcha.fields.client.submit",
-        return_value=RecaptchaResponse(is_valid=is_valid, action=action),
+        return_value=RecaptchaResponse(
+            is_valid=is_valid,
+            action=action,
+            extra_data={"score": 0.9} if is_valid else None,
+        ),
     )
     return patcher


### PR DESCRIPTION
Capturing the score and storing it on the registered user seems to not be possible without forking the library, and I'm not looking to maintain more stuff.
