### PR TITLE
Drop the bootstrap-select dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/polyfill": "^7.2.5",
         "bootstrap": "^3.4.1",
         "bootstrap-datepicker": "^1.9.0",
-        "bootstrap-select": "^1.13.8",
         "classnames": "^2.2.6",
         "clsx": "^2.1.1",
         "fine-uploader": "^5.16.2",
@@ -6394,14 +6393,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jquery": ">=1.7.1 <4.0.0"
-      }
-    },
-    "node_modules/bootstrap-select": {
-      "version": "1.13.18",
-      "license": "MIT",
-      "peerDependencies": {
-        "bootstrap": ">=3.0.0",
-        "jquery": "1.9.1 - 3"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/polyfill": "^7.2.5",
     "bootstrap": "^3.4.1",
     "bootstrap-datepicker": "^1.9.0",
-    "bootstrap-select": "^1.13.8",
     "classnames": "^2.2.6",
     "clsx": "^2.1.1",
     "fine-uploader": "^5.16.2",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,7 +2,6 @@ import '@babel/polyfill';
 import 'bootstrap';
 import 'bootstrap-datepicker';
 import 'bootstrap-datepicker/js/locales/bootstrap-datepicker.nl';
-import 'bootstrap-select';
 
 import {setCsrfTokenValue} from '@/data/api-client';
 
@@ -40,4 +39,3 @@ $('input.date').datepicker({
   language: 'nl',
   format: 'yyyy-mm-dd',
 });
-$('.selectpicker').selectpicker();

--- a/src/sass/partials/_forms.scss
+++ b/src/sass/partials/_forms.scss
@@ -75,20 +75,6 @@ form {
   }
 }
 
-.bootstrap-select .btn {
-  color: $text-color;
-
-  &.btn-default {
-    background-color: transparent;
-
-    &:hover {
-      background-color: inherit;
-      color: inherit;
-      text-decoration: none;
-    }
-  }
-}
-
 .formset-form {
   position: relative;
 

--- a/src/sass/vendor/_all.scss
+++ b/src/sass/vendor/_all.scss
@@ -1,5 +1,4 @@
 // bootstrap
-@import 'bootstrap-select/sass/bootstrap-select.scss';
 @import 'bootstrap-datepicker/dist/css/bootstrap-datepicker3';
 
 // react-dropzone

--- a/src/templates/default.form
+++ b/src/templates/default.form
@@ -129,29 +129,6 @@ TODO:
 {% endblock %}
 
 
-{% block SelectMultiple %}
-<div class="form-group clearfix">
-    {% reuse "_label" %}
-    <div class="{{ field_grid|default:'col-sm-10' }}">
-        {% if help_text %}<div class="input-group">{% endif %}
-        {% with input_type=input_type|default:form_field.field.widget.input_type|default:'text' %}
-        <select name="{{ html_name }}" id="{{ id }}"
-            {{ widget.attrs|flatattrs }} class="form-control selectpicker" multiple
-            data-live-search="{{ livesearch|default:True|yesno:"true,false" }}" title="{{ placeholder|default:_("Pick an option") }}"
-            data-size="{{ size|default:5 }}">
-        {% for val, display in choices %}
-            <option value="{{ val }}" {% if val in raw_value %}selected{% endif %}>{{ display }}</option>
-        {% endfor %}
-        </select>
-        {% endwith %}
-        {% reuse "_help" %}
-        {% if help_text %}</div>{% endif %}
-        {% reuse "_errors" %}
-    </div>
-</div>
-{% endblock SelectMultiple %}
-
-
 {% block CheckboxInput %}
 <div class="form-group clearfix">
     <div class="{{ label_grid_offset|default:'col-sm-offset-3' }} {{ field_grid|default:'col-sm-10' }}">

--- a/src/templates/horizontal.form
+++ b/src/templates/horizontal.form
@@ -121,27 +121,6 @@
 {% endblock %}
 
 
-{% block SelectMultiple %}
-<div class="form-group clearfix">
-    {% reuse "_label" %}
-    <div class="{{ field_grid|default:'col-sm-10' }}">
-        {% if help_text %}<div class="input-group">{% endif %}
-        <select name="{{ html_name }}" id="{{ id }}"
-            {{ widget.attrs|flatattrs }} class="form-control selectpicker" multiple
-            data-live-search="{{ livesearch|default:True|yesno:"true,false" }}" title="{{ placeholder|default:_("Pick an option") }}"
-            data-size="{{ size|default:5 }}">
-        {% for val, display in choices %}
-            <option value="{{ val }}" {% if val in value %}selected{% endif %}>{{ display }}</option>
-        {% endfor %}
-        </select>
-        {% reuse "_help" %}
-        {% if help_text %}</div>{% endif %}
-        {% reuse "_errors" %}
-    </div>
-</div>
-{% endblock SelectMultiple %}
-
-
 {% block RadioSelect %}
 <div class="form-group clearfix">
     {% reuse "_label" %}


### PR DESCRIPTION
It turns out to not be used anymore, effectively. Since a while ago the group builds pages have been made read-only for historical overview, which removed the usage of the bootstrap-select. Kitreviews and builds that use kits have already been converted to React/react-select.

Fixes #140